### PR TITLE
FIX: Support dark mode and improve readability

### DIFF
--- a/assets/stylesheets/common/plugin-manager.scss
+++ b/assets/stylesheets/common/plugin-manager.scss
@@ -36,7 +36,7 @@ $incompatible: #ef1700;
       align-items: center;
 
       .d-icon {
-        background-color: $primary-low;
+        background-color: var(--primary-low);
         border-radius: 50%;
         padding: 0.5em;
         margin-right: 0.75em;
@@ -66,7 +66,7 @@ $incompatible: #ef1700;
     }
 
     .detail-value {
-      background-color: $primary-low;
+      background-color: var(--primary-low);
       padding: 0.3em 0.6em;
       font-size: 1.1em;
       display: inline-block;
@@ -123,7 +123,7 @@ $incompatible: #ef1700;
   }
 
   .bottom {
-    border-bottom: 1px solid $primary-low;
+    border-bottom: 1px solid var(--primary-low);
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     grid-gap: 1em;
@@ -230,7 +230,7 @@ $incompatible: #ef1700;
     cursor: pointer;
 
     &.unknown {
-      color: $primary;
+      color: var(--primary-low);
     }
     &.recommended {
       color: $recommended;
@@ -253,8 +253,8 @@ $incompatible: #ef1700;
       }
 
       &.unknown {
-        background-color: rgba($primary-medium, 0.1);
-        border: 1px solid rgba($primary-medium, 0.5);
+        background-color: rgba(var(--primary-low-rgb), 0.05);
+        border: 1px solid rgba(var(--primary-low-rgb), 0.5);
       }
       &.recommended {
         background-color: rgba($recommended, 0.1);
@@ -348,7 +348,7 @@ $incompatible: #ef1700;
   }
 
   .btn-owner-logo {
-    border: 1px solid rgba($primary, 0.2);
+    border: 1px solid rgba(var(--primary-rgb), 0.2);
     background: transparent;
     padding: 0.45em 0.85em;
   }
@@ -453,7 +453,7 @@ $incompatible: #ef1700;
 
 .btn-plugin,
 a.btn-plugin {
-  border: 1px solid rgba($primary, 0.2);
+  border: 1px solid rgba(var(--primary-rgb), 0.2);
   background: transparent;
   padding: 0.45em 0.85em;
   color: var(--primary);


### PR DESCRIPTION
### Auto dark mode on plugins.discourse.pavilion.tech is causing readability issues:
![Screen Shot 2022-01-11 at 1 46 40 PM](https://user-images.githubusercontent.com/30090424/149026479-1f1a75ad-65b0-465d-84c2-bec238047b5f.png)
![Screen Shot 2022-01-11 at 1 46 47 PM](https://user-images.githubusercontent.com/30090424/149026497-6914153f-a6e1-44ae-a2d0-34fcd16dc1eb.png)
![Screen Shot 2022-01-11 at 1 46 59 PM](https://user-images.githubusercontent.com/30090424/149026521-c86c91d9-f384-446c-b66e-479672919f22.png)

### This PR aims to remove those issues by supporting dark mode through the use of Discourse's existing CSS custom properties.
