### PR TITLE
FEATURE: add date time stamps to detail status on dashboard

### DIFF
--- a/app/serializers/plugin_manager/plugin_status_serializer.rb
+++ b/app/serializers/plugin_manager/plugin_status_serializer.rb
@@ -15,11 +15,12 @@ class PluginManager::PluginStatusSerializer < ::ApplicationSerializer
   end
 
   def status_changed_at
-    defined?(object.status_changed_at) ? object.status_changed_at.to_time.strftime('%F %T') : ""
+    byebug
+    defined?(object.status_changed_at) && !object.status_changed_at.nil? ? object.status_changed_at.to_time.strftime('%F %T') : ""
   end
 
   def last_status_at
-    defined?(object.last_status_at) ? object.last_status_at.to_time.strftime('%F %T') : ""
+    defined?(object.last_status_at) && !object.last_status_at.nil? ? object.last_status_at.to_time.strftime('%F %T') : ""
   end
 
   def test_status

--- a/app/serializers/plugin_manager/plugin_status_serializer.rb
+++ b/app/serializers/plugin_manager/plugin_status_serializer.rb
@@ -7,6 +7,7 @@ class PluginManager::PluginStatusSerializer < ::ApplicationSerializer
              :discourse_sha,
              :status,
              :status_changed_at,
+             :last_status_at,
              :test_status
 
   def status

--- a/app/serializers/plugin_manager/plugin_status_serializer.rb
+++ b/app/serializers/plugin_manager/plugin_status_serializer.rb
@@ -14,6 +14,14 @@ class PluginManager::PluginStatusSerializer < ::ApplicationSerializer
     ::PluginManager::Plugin::Status.statuses.keys[object.status].to_s
   end
 
+  def status_changed_at
+    object.status_changed_at.to_time.strftime('%F %T')
+  end
+
+  def last_status_at
+    object.last_status_at.to_time.strftime('%F %T')
+  end
+
   def test_status
     ::PluginManager::TestManager.status.keys[object.test_status].to_s
   end

--- a/app/serializers/plugin_manager/plugin_status_serializer.rb
+++ b/app/serializers/plugin_manager/plugin_status_serializer.rb
@@ -15,7 +15,6 @@ class PluginManager::PluginStatusSerializer < ::ApplicationSerializer
   end
 
   def status_changed_at
-    byebug
     defined?(object.status_changed_at) && !object.status_changed_at.nil? ? object.status_changed_at.to_time.strftime('%F %T') : ""
   end
 

--- a/app/serializers/plugin_manager/plugin_status_serializer.rb
+++ b/app/serializers/plugin_manager/plugin_status_serializer.rb
@@ -15,11 +15,11 @@ class PluginManager::PluginStatusSerializer < ::ApplicationSerializer
   end
 
   def status_changed_at
-    object.status_changed_at.to_time.strftime('%F %T')
+    defined?(object.status_changed_at) ? object.status_changed_at.to_time.strftime('%F %T') : ""
   end
 
   def last_status_at
-    object.last_status_at.to_time.strftime('%F %T')
+    defined?(object.last_status_at) ? object.last_status_at.to_time.strftime('%F %T') : ""
   end
 
   def test_status

--- a/assets/javascripts/discourse/components/plugin-status-detail.js.es6
+++ b/assets/javascripts/discourse/components/plugin-status-detail.js.es6
@@ -10,14 +10,18 @@ export default Component.extend({
   @discourseComputed(
     "plugin.name",
     "plugin.status.status",
+    "plugin.status.last_status_at",
+    "plugin.status.status_changed_at",
     "plugin.status.branch",
     "discourse.branch"
   )
-  detailDescription(pluginName, pluginStatus, pluginBranch, discourseBranch) {
+  detailDescription(pluginName, pluginStatus, pluginLastStatusAt, pluginStatusChangedAt, pluginBranch, discourseBranch) {
     return I18n.t(`server_status.plugin.status.${pluginStatus}.description`, {
       plugin_name: pluginName,
       plugin_branch: pluginBranch,
       discourse_branch: discourseBranch,
+      plugin_last_status_at: pluginLastStatusAt,
+      plugin_status_changed_at: pluginStatusChangedAt
     });
   },
 

--- a/assets/javascripts/discourse/components/plugin-status-detail.js.es6
+++ b/assets/javascripts/discourse/components/plugin-status-detail.js.es6
@@ -20,8 +20,8 @@ export default Component.extend({
       plugin_name: pluginName,
       plugin_branch: pluginBranch,
       discourse_branch: discourseBranch,
-      plugin_last_status_at: pluginLastStatusAt,
-      plugin_status_changed_at: pluginStatusChangedAt
+      plugin_last_status_at: moment(pluginLastStatusAt).fromNow(),
+      plugin_status_changed_at: moment(pluginStatusChangedAt).fromNow()
     });
   },
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -73,15 +73,15 @@ en:
           compatible:
             title: Compatible
             detail_title: "is compatible with"
-            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}. Last status update was at %(plugin_last_status_at), status last changed at %(plugin_status_changed_at)"
+            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}. Last status update was %(plugin_last_status_at), status last changed %(plugin_status_changed_at)"
           incompatible:
             title: Incompatible
             detail_title: "is not compatible with"
-            description: "%{plugin_name} %{plugin_branch} does not load succesfully on Discourse %{discourse_branch}. Last status update was at %(plugin_last_status_at), status last changed at %(plugin_status_changed_at)"
+            description: "%{plugin_name} %{plugin_branch} does not load succesfully on Discourse %{discourse_branch}. Last status update was %(plugin_last_status_at), status last changed %(plugin_status_changed_at)"
           tests_failing:
             title: Tests Failing
             detail_title: "tests are failing on"
-            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}, but its tests are failing. Last status update was at %(plugin_last_status_at), status last changed at %(plugin_status_changed_at)"
+            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}, but its tests are failing. Last status update was %(plugin_last_status_at), status last changed %(plugin_status_changed_at)"
         issue_report: issue report
         test_log: test log
         log:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -73,15 +73,15 @@ en:
           compatible:
             title: Compatible
             detail_title: "is compatible with"
-            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}."
+            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}. Last status update was at %(plugin_last_status_at), status last changed at %(plugin_status_changed_at)"
           incompatible:
             title: Incompatible
             detail_title: "is not compatible with"
-            description: "%{plugin_name} %{plugin_branch} does not load succesfully on Discourse %{discourse_branch}."
+            description: "%{plugin_name} %{plugin_branch} does not load succesfully on Discourse %{discourse_branch}. Last status update was at %(plugin_last_status_at), status last changed at %(plugin_status_changed_at)"
           tests_failing:
             title: Tests Failing
             detail_title: "tests are failing on"
-            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}, but its tests are failing."
+            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}, but its tests are failing. Last status update was at %(plugin_last_status_at), status last changed at %(plugin_status_changed_at)"
         issue_report: issue report
         test_log: test log
         log:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -73,15 +73,15 @@ en:
           compatible:
             title: Compatible
             detail_title: "is compatible with"
-            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}. Last status update was %(plugin_last_status_at), status last changed %(plugin_status_changed_at)"
+            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}. Last status update was %{plugin_last_status_at}, status last changed %{plugin_status_changed_at}"
           incompatible:
             title: Incompatible
             detail_title: "is not compatible with"
-            description: "%{plugin_name} %{plugin_branch} does not load succesfully on Discourse %{discourse_branch}. Last status update was %(plugin_last_status_at), status last changed %(plugin_status_changed_at)"
+            description: "%{plugin_name} %{plugin_branch} does not load succesfully on Discourse %{discourse_branch}. Last status update was %{plugin_last_status_at}, status last changed %{plugin_status_changed_at}"
           tests_failing:
             title: Tests Failing
             detail_title: "tests are failing on"
-            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}, but its tests are failing. Last status update was %(plugin_last_status_at), status last changed %(plugin_status_changed_at)"
+            description: "%{plugin_name} %{plugin_branch} loads succesfully on Discourse %{discourse_branch}, but its tests are failing. Last status update was %{plugin_last_status_at}, status last changed %{plugin_status_changed_at}"
         issue_report: issue report
         test_log: test log
         log:

--- a/lib/plugin_manager/plugin/status.rb
+++ b/lib/plugin_manager/plugin/status.rb
@@ -17,6 +17,7 @@ class ::PluginManager::Plugin::Status
 
   attr_accessor :status,
                 :status_changed_at,
+                :last_status_at,
                 :test_status
 
   def initialize(name, attrs)
@@ -30,6 +31,7 @@ class ::PluginManager::Plugin::Status
     # changable attrs
     @status = attrs[:status].to_i
     @status_changed_at = attrs[:status_changed_at]
+    @last_status_at = attrs[:last_status_at]
     @test_status = attrs[:test_status].present? ? attrs[:test_status].to_i : nil
   end
 
@@ -95,11 +97,11 @@ class ::PluginManager::Plugin::Status
     new_attrs[:status] = normalize_status(**new_attrs)
     status_changed = current_status && (current_status.status != new_attrs[:status])
     new_attrs[:status_changed_at] = (!current_status || status_changed) ? Time.now : current_status.status_changed_at
+    new_attrs[:last_status_at] = Time.now
 
     key = status_key(name, git[:branch], git[:discourse_branch])
     new_attrs[:name] = name
     required_git_attrs.each { |attr| new_attrs[attr] = git[attr] }
-
     ::PluginManagerStore.set(db_key, key, new_attrs)
 
     if status_changed

--- a/lib/plugin_manager/plugin/status.rb
+++ b/lib/plugin_manager/plugin/status.rb
@@ -102,6 +102,7 @@ class ::PluginManager::Plugin::Status
     key = status_key(name, git[:branch], git[:discourse_branch])
     new_attrs[:name] = name
     required_git_attrs.each { |attr| new_attrs[attr] = git[attr] }
+
     ::PluginManagerStore.set(db_key, key, new_attrs)
 
     if status_changed

--- a/spec/components/plugin_manager/plugin_status_spec.rb
+++ b/spec/components/plugin_manager/plugin_status_spec.rb
@@ -41,6 +41,9 @@ describe PluginManager::Plugin::Status do
     expect(
       described_class.get(compatible_plugin, plugin_branch, discourse_branch).status
     ).to eq(described_class.statuses[:tests_failing])
+    expect(
+      described_class.get(compatible_plugin, plugin_branch, discourse_branch).last_status_at.to_time.strftime('%F %T')
+    ).to eq(Time.now.strftime('%F %T'))
   end
 
   context "status change" do

--- a/spec/requests/plugin_manager/plugin_status_controller_spec.rb
+++ b/spec/requests/plugin_manager/plugin_status_controller_spec.rb
@@ -14,6 +14,7 @@ describe PluginManager::PluginStatusController do
   it "indexes plugin statuses" do
     setup_test_plugin(compatible_plugin)
     setup_test_plugin(third_party_plugin)
+    freeze_time Time.now
     PluginManager::Plugin::Status.update(compatible_plugin, git, compatible_status)
     PluginManager::Plugin::Status.update(third_party_plugin, git, compatible_status)
 
@@ -35,6 +36,7 @@ describe PluginManager::PluginStatusController do
     expect(response.status).to eq(200)
     expect(response.parsed_body['total']).to eq(2)
     expect(response.parsed_body['statuses'].first['status']).to eq('compatible')
+    expect(response.parsed_body['statuses'].first['last_status_at'].to_time.strftime('%F %T')).to eq(Time.now.strftime('%F %T'))
   end
 
   it "updates a plugin status" do

--- a/spec/requests/plugin_manager/plugin_status_controller_spec.rb
+++ b/spec/requests/plugin_manager/plugin_status_controller_spec.rb
@@ -36,7 +36,7 @@ describe PluginManager::PluginStatusController do
     expect(response.status).to eq(200)
     expect(response.parsed_body['total']).to eq(2)
     expect(response.parsed_body['statuses'].first['status']).to eq('compatible')
-    expect(response.parsed_body['statuses'].first['last_status_at'].to_time.strftime('%F %T')).to eq(Time.now.strftime('%F %T'))
+    expect(response.parsed_body['statuses'].first['last_status_at']).to eq(Time.now.strftime('%F %T'))
   end
 
   it "updates a plugin status" do


### PR DESCRIPTION
* Captures time of update and adds `last_status_at` field
* Exposes this and `status_changed_at` on dashboard interface per plugin as detailed status

![image](https://user-images.githubusercontent.com/35533304/216821469-6f28b474-9686-4e79-9f82-a10ce90a8569.png)
