### PR TITLE
CI error handling improvements

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -19,8 +19,8 @@ en:
       fixed:
         body: "%{plugin_name} has recovered from this issue."
     test:
-      error: "The tests are failing."
-      error_test: "The '%{test_name}' test is failing."
+      failed: "%{test_name} has failed."
+      failed_with_message: "%{test_name} has failed: %{message}"
     plugin:
       documentation_category_description: Documentation for the %{plugin_name} plugin.
       issues_category_title: Issues for the %{plugin_name} plugin.

--- a/lib/plugin_manager/plugin.rb
+++ b/lib/plugin_manager/plugin.rb
@@ -142,7 +142,7 @@ class ::PluginManager::Plugin
     new_attrs = update_repository_attrs(new_attrs[:url], new_attrs)
     PluginManagerStore.set(::PluginManager::NAMESPACE, plugin_name, new_attrs)
 
-    status_attrs = attrs.slice(:status, :test_status)
+    status_attrs = attrs.slice(:status, :test_status, :backtrace, :message)
     git = attrs.slice(*PluginManager::Plugin::Status.required_git_attrs)
 
     if status_attrs.present? && git.present?

--- a/lib/plugin_manager/test_host.rb
+++ b/lib/plugin_manager/test_host.rb
@@ -11,7 +11,9 @@ class ::PluginManager::TestHost
 
   attr_accessor :plugin,
                 :branch,
-                :discourse_branch
+                :discourse_branch,
+                :manager,
+                :test_error
 
   ## overide in child
   def status_path

--- a/lib/plugin_manager/test_host/github.rb
+++ b/lib/plugin_manager/test_host/github.rb
@@ -11,26 +11,68 @@ class PluginManager::TestHost::Github < PluginManager::TestHost
   end
 
   def status_path
-    "repos#{repo_path}/actions/runs?branch=#{@branch}&status=completed&per_page=1&page=1"
+    "repos#{repo_path}/actions/runs?branch=#{@branch}&status=completed&per_page=5&page=1"
   end
 
   def config_path
     "repos#{repo_path}/contents/#{@config}"
   end
 
+  def tests_workflow_name
+    "Discourse Plugin"
+  end
+
+  def check_runs_path(check_suite_id)
+    "repos#{repo_path}/check-suites/#{check_suite_id}/check-runs?status=completed"
+  end
+
+  def test_check_runs
+    %w(frontend_tests backend_tests)
+  end
+
+  def test_check_run?(run)
+    test_check_runs.any? { |tcr| run['name'].include?(tcr) }
+  end
+
+  def failed_run?(run)
+    run['conclusion'] === "failure"
+  end
+
+  def run_error_message(run)
+    message = I18n.t("plugin_manager.test.failed", test_name: run["name"])
+    return message unless run["output"] && run["output"]["annotations_url"]
+
+    annotations = @manager.request(nil, url: run["output"]["annotations_url"])
+    message = annotations.map { |a| a['message'] }.join(', ')
+    I18n.t("plugin_manager.test.failed_with_message", test_name: run["name"], message: message)
+  end
+
+  def build_test_error(runs)
+    message = runs.map { |r| run_error_message(r) }.join(', ')
+  end
+
   def get_status_from_response(response)
-    runs = response['workflow_runs']
-    return nil unless runs.present?
-    latest_run = runs.first
+    latest_run = response['workflow_runs'].find { |r| r["name"] === tests_workflow_name }
+    return nil unless latest_run.present?
 
     @test_sha = latest_run['head_sha']
     @test_branch = latest_run['head_branch']
     @test_name = latest_run['name']
     @test_url = latest_run['html_url']
+    @check_suite_id = latest_run['check_suite_id']
 
     if latest_run["conclusion"] === "success"
       PluginManager::TestManager.status[:passing]
     else
+      check_runs = @manager.request(check_runs_path(latest_run["check_suite_id"]))
+
+      if check_runs && check_runs['check_runs']
+        failing_test_runs = check_runs['check_runs'].select { |cr| test_check_run?(cr) && failed_run?(cr) }
+        return PluginManager::TestManager.status[:passing] if failing_test_runs.blank?
+
+        @test_error = build_test_error(failing_test_runs)
+      end
+
       PluginManager::TestManager.status[:failing]
     end
   end

--- a/spec/components/plugin_manager/test_manager_spec.rb
+++ b/spec/components/plugin_manager/test_manager_spec.rb
@@ -39,7 +39,7 @@ describe PluginManager::TestManager do
   end
 
   it "does nothing if plugin is not using Discourse Plugin workflow" do
-    set_workflow(0,'name', 'Plugin Tests')
+    set_workflow(0, 'name', 'Plugin Tests')
     subject.update(compatible_plugin)
     expect(status.test_status).to eq(nil)
   end
@@ -60,7 +60,7 @@ describe PluginManager::TestManager do
   it "sets a failing status and message when tests are failing" do
     PluginManager::Plugin::Status.update(compatible_plugin, git, compatible_status)
 
-    set_workflow(0,'conclusion', 'failure')
+    set_workflow(0, 'conclusion', 'failure')
     set_test_check(2, 'conclusion', 'failure')
     stub_github_annotations_request(test_annotations_response_body)
 

--- a/spec/components/plugin_manager/test_manager_spec.rb
+++ b/spec/components/plugin_manager/test_manager_spec.rb
@@ -1,9 +1,34 @@
 # frozen_string_literal: true
 require_relative '../../plugin_helper'
 
+# workflow indexes
+# 0: "Discourse Plugin"
+
+# text check indexes
+# 0: "ci / linting"
+# 1: "ci / check_for_tests"
+# 2: "ci / frontend_tests"
+# 3: "ci / backend_tests"
+
 describe PluginManager::TestManager do
   let(:incompatible_plugin) { "incompatible_plugin" }
   let(:test_response_body) { File.read("#{fixture_dir}/github/runs.json") }
+  let(:test_checks_response_body) { File.read("#{fixture_dir}/github/check_runs.json") }
+  let(:test_annotations_response_body) { File.read("#{fixture_dir}/github/annotations.json") }
+  let(:subject) { described_class.new("github", plugin_branch, discourse_branch) }
+  let(:status) { PluginManager::Plugin::Status.get(compatible_plugin, plugin_branch, discourse_branch) }
+
+  def set_workflow(index, key, value)
+    test_response_json = JSON.parse(test_response_body)
+    test_response_json['workflow_runs'][index][key] = value
+    stub_github_test_request(JSON.generate(test_response_json))
+  end
+
+  def set_test_check(index, key, value)
+    test_checks_response_json = JSON.parse(test_checks_response_body)
+    test_checks_response_json['check_runs'][index][key] = value
+    stub_github_test_check_request(JSON.generate(test_checks_response_json))
+  end
 
   before do
     stub_github_user_request
@@ -13,19 +38,44 @@ describe PluginManager::TestManager do
     setup_test_plugin(compatible_plugin)
   end
 
-  it "updates plugin tests" do
-    manager = described_class.new("github", plugin_branch, discourse_branch)
-    manager.update(compatible_plugin)
+  it "does nothing if plugin is not using Discourse Plugin workflow" do
+    set_workflow(0,'name', 'Plugin Tests')
+    subject.update(compatible_plugin)
+    expect(status.test_status).to eq(nil)
+  end
 
-    status = PluginManager::Plugin::Status.get(compatible_plugin, plugin_branch, discourse_branch)
+  it "sets a passing test status when tests are passing" do
+    subject.update(compatible_plugin)
     expect(status.test_status).to eq(described_class.status[:passing])
+  end
 
-    test_response_json = JSON.parse(test_response_body)
-    test_response_json['workflow_runs'][0]['conclusion'] = 'failure'
-    stub_github_test_request(JSON.generate(test_response_json))
-    manager.update(compatible_plugin)
+  it "sets a passing test status when linting is failing" do
+    set_workflow(0, 'conclusion', 'failure')
+    set_test_check(0, 'conclusion', 'failure')
 
-    status = PluginManager::Plugin::Status.get(compatible_plugin, plugin_branch, discourse_branch)
+    subject.update(compatible_plugin)
+    expect(status.test_status).to eq(described_class.status[:passing])
+  end
+
+  it "sets a failing status and message when tests are failing" do
+    PluginManager::Plugin::Status.update(compatible_plugin, git, compatible_status)
+
+    set_workflow(0,'conclusion', 'failure')
+    set_test_check(2, 'conclusion', 'failure')
+    stub_github_annotations_request(test_annotations_response_body)
+
+    PluginManager::StatusHandler.any_instance.expects(:perform).with(
+      PluginManager::Plugin::Status.statuses[:compatible],
+      PluginManager::Plugin::Status.statuses[:tests_failing],
+      {
+        message: I18n.t("plugin_manager.test.failed_with_message",
+          test_name: "ci / frontend_tests",
+          message: "QUnit Test Failure: Acceptance: Field | Fields: Text, Process completed with exit code 1."
+        )
+      }
+    ).returns(true)
+
+    subject.update(compatible_plugin)
     expect(status.test_status).to eq(described_class.status[:failing])
   end
 end

--- a/spec/fixtures/github/annotations.json
+++ b/spec/fixtures/github/annotations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "path": ".github",
+    "blob_href": "https://github.com/paviliondev/discourse-compatible-plugin/blob/d2fbe349ee9f86d05fdcdbf20e48fc6edd450217/.github",
+    "start_line": 846,
+    "start_column": null,
+    "end_line": 846,
+    "end_column": null,
+    "annotation_level": "failure",
+    "title": "",
+    "message": "QUnit Test Failure: Acceptance: Field | Fields: Text",
+    "raw_details": ""
+  },
+  {
+    "path": ".github",
+    "blob_href": "https://github.com/paviliondev/discourse-compatible-plugin/blob/d2fbe349ee9f86d05fdcdbf20e48fc6edd450217/.github",
+    "start_line": 894,
+    "start_column": null,
+    "end_line": 894,
+    "end_column": null,
+    "annotation_level": "failure",
+    "title": "",
+    "message": "Process completed with exit code 1.",
+    "raw_details": ""
+  }
+]

--- a/spec/fixtures/github/check_runs.json
+++ b/spec/fixtures/github/check_runs.json
@@ -1,0 +1,392 @@
+{
+  "total_count": 4,
+  "check_runs": [{
+    "id": 12020020791,
+    "name": "ci / linting",
+    "node_id": "CR_kwDOBjsWBc8AAAACzHL2Nw",
+    "head_sha": "d2fbe349ee9f86d05fdcdbf20e48fc6edd450217",
+    "external_id": "d4dc160d-cdc7-52f9-e74e-ba7043a38170",
+    "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/check-runs/12020020791",
+    "html_url": "https://github.com/paviliondev/discourse-compatible-plugin/actions/runs/4426710517/jobs/7763330549",
+    "details_url": "https://github.com/paviliondev/discourse-compatible-plugin/actions/runs/4426710517/jobs/7763330549",
+    "status": "completed",
+    "conclusion": "success",
+    "started_at": "2023-03-15T13:14:54Z",
+    "completed_at": "2023-03-15T13:15:26Z",
+    "output": {
+      "title": null,
+      "summary": null,
+      "text": null,
+      "annotations_count": 0,
+      "annotations_url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/check-runs/12020020791/annotations"
+    },
+    "check_suite": {
+      "id": 11578437050
+    },
+    "app": {
+      "id": 15368,
+      "slug": "github-actions",
+      "node_id": "MDM6QXBwMTUzNjg=",
+      "owner": {
+        "login": "github",
+        "id": 9919,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjk5MTk=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/9919?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/github",
+        "html_url": "https://github.com/github",
+        "followers_url": "https://api.github.com/users/github/followers",
+        "following_url": "https://api.github.com/users/github/following{/other_user}",
+        "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+        "organizations_url": "https://api.github.com/users/github/orgs",
+        "repos_url": "https://api.github.com/users/github/repos",
+        "events_url": "https://api.github.com/users/github/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/github/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "name": "GitHub Actions",
+      "description": "Automate your workflow from idea to production",
+      "external_url": "https://help.github.com/en/actions",
+      "html_url": "https://github.com/apps/github-actions",
+      "created_at": "2018-07-30T09:30:17Z",
+      "updated_at": "2019-12-10T19:04:12Z",
+      "permissions": {
+        "actions": "write",
+        "administration": "read",
+        "checks": "write",
+        "contents": "write",
+        "deployments": "write",
+        "discussions": "write",
+        "issues": "write",
+        "merge_queues": "write",
+        "metadata": "read",
+        "packages": "write",
+        "pages": "write",
+        "pull_requests": "write",
+        "repository_hooks": "write",
+        "repository_projects": "write",
+        "security_events": "write",
+        "statuses": "write",
+        "vulnerability_alerts": "read"
+      },
+      "events": ["branch_protection_rule", "check_run", "check_suite", "create", "delete", "deployment", "deployment_status", "discussion", "discussion_comment", "fork", "gollum", "issues", "issue_comment", "label", "merge_group", "milestone", "page_build", "project", "project_card", "project_column", "public", "pull_request", "pull_request_review", "pull_request_review_comment", "push", "registry_package", "release", "repository", "repository_dispatch", "status", "watch", "workflow_dispatch", "workflow_run"]
+    },
+    "pull_requests": [{
+      "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/pulls/230",
+      "id": 1276825476,
+      "number": 230,
+      "head": {
+        "ref": "failing_frontend",
+        "sha": "d2fbe349ee9f86d05fdcdbf20e48fc6edd450217",
+        "repo": {
+          "id": 104535557,
+          "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin",
+          "name": "discourse-compatible-plugin"
+        }
+      },
+      "base": {
+        "ref": "main",
+        "sha": "345885bdbd16a6be10ad81d6a56dcbbdaff0cdb4",
+        "repo": {
+          "id": 104535557,
+          "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin",
+          "name": "discourse-compatible-plugin"
+        }
+      }
+    }]
+  }, {
+    "id": 12020021111,
+    "name": "ci / check_for_tests",
+    "node_id": "CR_kwDOBjsWBc8AAAACzHL3dw",
+    "head_sha": "d2fbe349ee9f86d05fdcdbf20e48fc6edd450217",
+    "external_id": "3294c812-7105-5dd0-cf11-c1c9a665dc99",
+    "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/check-runs/12020021111",
+    "html_url": "https://github.com/paviliondev/discourse-compatible-plugin/actions/runs/4426710517/jobs/7763330807",
+    "details_url": "https://github.com/paviliondev/discourse-compatible-plugin/actions/runs/4426710517/jobs/7763330807",
+    "status": "completed",
+    "conclusion": "success",
+    "started_at": "2023-03-15T13:14:52Z",
+    "completed_at": "2023-03-15T13:14:55Z",
+    "output": {
+      "title": null,
+      "summary": null,
+      "text": null,
+      "annotations_count": 0,
+      "annotations_url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/check-runs/12020021111/annotations"
+    },
+    "check_suite": {
+      "id": 11578437050
+    },
+    "app": {
+      "id": 15368,
+      "slug": "github-actions",
+      "node_id": "MDM6QXBwMTUzNjg=",
+      "owner": {
+        "login": "github",
+        "id": 9919,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjk5MTk=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/9919?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/github",
+        "html_url": "https://github.com/github",
+        "followers_url": "https://api.github.com/users/github/followers",
+        "following_url": "https://api.github.com/users/github/following{/other_user}",
+        "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+        "organizations_url": "https://api.github.com/users/github/orgs",
+        "repos_url": "https://api.github.com/users/github/repos",
+        "events_url": "https://api.github.com/users/github/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/github/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "name": "GitHub Actions",
+      "description": "Automate your workflow from idea to production",
+      "external_url": "https://help.github.com/en/actions",
+      "html_url": "https://github.com/apps/github-actions",
+      "created_at": "2018-07-30T09:30:17Z",
+      "updated_at": "2019-12-10T19:04:12Z",
+      "permissions": {
+        "actions": "write",
+        "administration": "read",
+        "checks": "write",
+        "contents": "write",
+        "deployments": "write",
+        "discussions": "write",
+        "issues": "write",
+        "merge_queues": "write",
+        "metadata": "read",
+        "packages": "write",
+        "pages": "write",
+        "pull_requests": "write",
+        "repository_hooks": "write",
+        "repository_projects": "write",
+        "security_events": "write",
+        "statuses": "write",
+        "vulnerability_alerts": "read"
+      },
+      "events": ["branch_protection_rule", "check_run", "check_suite", "create", "delete", "deployment", "deployment_status", "discussion", "discussion_comment", "fork", "gollum", "issues", "issue_comment", "label", "merge_group", "milestone", "page_build", "project", "project_card", "project_column", "public", "pull_request", "pull_request_review", "pull_request_review_comment", "push", "registry_package", "release", "repository", "repository_dispatch", "status", "watch", "workflow_dispatch", "workflow_run"]
+    },
+    "pull_requests": [{
+      "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/pulls/230",
+      "id": 1276825476,
+      "number": 230,
+      "head": {
+        "ref": "failing_frontend",
+        "sha": "d2fbe349ee9f86d05fdcdbf20e48fc6edd450217",
+        "repo": {
+          "id": 104535557,
+          "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin",
+          "name": "discourse-compatible-plugin"
+        }
+      },
+      "base": {
+        "ref": "main",
+        "sha": "345885bdbd16a6be10ad81d6a56dcbbdaff0cdb4",
+        "repo": {
+          "id": 104535557,
+          "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin",
+          "name": "discourse-compatible-plugin"
+        }
+      }
+    }]
+  }, {
+    "id": 12020026492,
+    "name": "ci / frontend_tests",
+    "node_id": "CR_kwDOBjsWBc8AAAACzHMMfA",
+    "head_sha": "d2fbe349ee9f86d05fdcdbf20e48fc6edd450217",
+    "external_id": "6bcf58ee-a21d-52a8-20df-261000094ddc",
+    "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/check-runs/12020026492",
+    "html_url": "https://github.com/paviliondev/discourse-compatible-plugin/actions/runs/4426710517/jobs/7763334954",
+    "details_url": "https://github.com/paviliondev/discourse-compatible-plugin/actions/runs/4426710517/jobs/7763334954",
+    "status": "completed",
+    "conclusion": "success",
+    "started_at": "2023-03-15T13:15:03Z",
+    "completed_at": "2023-03-15T13:19:23Z",
+    "output": {
+      "title": null,
+      "summary": null,
+      "text": null,
+      "annotations_count": 2,
+      "annotations_url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/check-runs/12020026492/annotations"
+    },
+    "check_suite": {
+      "id": 11578437050
+    },
+    "app": {
+      "id": 15368,
+      "slug": "github-actions",
+      "node_id": "MDM6QXBwMTUzNjg=",
+      "owner": {
+        "login": "github",
+        "id": 9919,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjk5MTk=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/9919?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/github",
+        "html_url": "https://github.com/github",
+        "followers_url": "https://api.github.com/users/github/followers",
+        "following_url": "https://api.github.com/users/github/following{/other_user}",
+        "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+        "organizations_url": "https://api.github.com/users/github/orgs",
+        "repos_url": "https://api.github.com/users/github/repos",
+        "events_url": "https://api.github.com/users/github/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/github/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "name": "GitHub Actions",
+      "description": "Automate your workflow from idea to production",
+      "external_url": "https://help.github.com/en/actions",
+      "html_url": "https://github.com/apps/github-actions",
+      "created_at": "2018-07-30T09:30:17Z",
+      "updated_at": "2019-12-10T19:04:12Z",
+      "permissions": {
+        "actions": "write",
+        "administration": "read",
+        "checks": "write",
+        "contents": "write",
+        "deployments": "write",
+        "discussions": "write",
+        "issues": "write",
+        "merge_queues": "write",
+        "metadata": "read",
+        "packages": "write",
+        "pages": "write",
+        "pull_requests": "write",
+        "repository_hooks": "write",
+        "repository_projects": "write",
+        "security_events": "write",
+        "statuses": "write",
+        "vulnerability_alerts": "read"
+      },
+      "events": ["branch_protection_rule", "check_run", "check_suite", "create", "delete", "deployment", "deployment_status", "discussion", "discussion_comment", "fork", "gollum", "issues", "issue_comment", "label", "merge_group", "milestone", "page_build", "project", "project_card", "project_column", "public", "pull_request", "pull_request_review", "pull_request_review_comment", "push", "registry_package", "release", "repository", "repository_dispatch", "status", "watch", "workflow_dispatch", "workflow_run"]
+    },
+    "pull_requests": [{
+      "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/pulls/230",
+      "id": 1276825476,
+      "number": 230,
+      "head": {
+        "ref": "failing_frontend",
+        "sha": "d2fbe349ee9f86d05fdcdbf20e48fc6edd450217",
+        "repo": {
+          "id": 104535557,
+          "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin",
+          "name": "discourse-compatible-plugin"
+        }
+      },
+      "base": {
+        "ref": "main",
+        "sha": "345885bdbd16a6be10ad81d6a56dcbbdaff0cdb4",
+        "repo": {
+          "id": 104535557,
+          "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin",
+          "name": "discourse-compatible-plugin"
+        }
+      }
+    }]
+  }, {
+    "id": 12020026914,
+    "name": "ci / backend_tests",
+    "node_id": "CR_kwDOBjsWBc8AAAACzHMOIg",
+    "head_sha": "d2fbe349ee9f86d05fdcdbf20e48fc6edd450217",
+    "external_id": "c9a04801-ea84-5ae3-827f-c524bf408188",
+    "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/check-runs/12020026914",
+    "html_url": "https://github.com/paviliondev/discourse-compatible-plugin/actions/runs/4426710517/jobs/7763335278",
+    "details_url": "https://github.com/paviliondev/discourse-compatible-plugin/actions/runs/4426710517/jobs/7763335278",
+    "status": "completed",
+    "conclusion": "success",
+    "started_at": "2023-03-15T13:15:04Z",
+    "completed_at": "2023-03-15T13:18:09Z",
+    "output": {
+      "title": null,
+      "summary": null,
+      "text": null,
+      "annotations_count": 0,
+      "annotations_url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/check-runs/12020026914/annotations"
+    },
+    "check_suite": {
+      "id": 11578437050
+    },
+    "app": {
+      "id": 15368,
+      "slug": "github-actions",
+      "node_id": "MDM6QXBwMTUzNjg=",
+      "owner": {
+        "login": "github",
+        "id": 9919,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjk5MTk=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/9919?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/github",
+        "html_url": "https://github.com/github",
+        "followers_url": "https://api.github.com/users/github/followers",
+        "following_url": "https://api.github.com/users/github/following{/other_user}",
+        "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+        "organizations_url": "https://api.github.com/users/github/orgs",
+        "repos_url": "https://api.github.com/users/github/repos",
+        "events_url": "https://api.github.com/users/github/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/github/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "name": "GitHub Actions",
+      "description": "Automate your workflow from idea to production",
+      "external_url": "https://help.github.com/en/actions",
+      "html_url": "https://github.com/apps/github-actions",
+      "created_at": "2018-07-30T09:30:17Z",
+      "updated_at": "2019-12-10T19:04:12Z",
+      "permissions": {
+        "actions": "write",
+        "administration": "read",
+        "checks": "write",
+        "contents": "write",
+        "deployments": "write",
+        "discussions": "write",
+        "issues": "write",
+        "merge_queues": "write",
+        "metadata": "read",
+        "packages": "write",
+        "pages": "write",
+        "pull_requests": "write",
+        "repository_hooks": "write",
+        "repository_projects": "write",
+        "security_events": "write",
+        "statuses": "write",
+        "vulnerability_alerts": "read"
+      },
+      "events": ["branch_protection_rule", "check_run", "check_suite", "create", "delete", "deployment", "deployment_status", "discussion", "discussion_comment", "fork", "gollum", "issues", "issue_comment", "label", "merge_group", "milestone", "page_build", "project", "project_card", "project_column", "public", "pull_request", "pull_request_review", "pull_request_review_comment", "push", "registry_package", "release", "repository", "repository_dispatch", "status", "watch", "workflow_dispatch", "workflow_run"]
+    },
+    "pull_requests": [{
+      "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin/pulls/230",
+      "id": 1276825476,
+      "number": 230,
+      "head": {
+        "ref": "failing_frontend",
+        "sha": "d2fbe349ee9f86d05fdcdbf20e48fc6edd450217",
+        "repo": {
+          "id": 104535557,
+          "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin",
+          "name": "discourse-compatible-plugin"
+        }
+      },
+      "base": {
+        "ref": "main",
+        "sha": "345885bdbd16a6be10ad81d6a56dcbbdaff0cdb4",
+        "repo": {
+          "id": 104535557,
+          "url": "https://api.github.com/repos/paviliondev/discourse-compatible-plugin",
+          "name": "discourse-compatible-plugin"
+        }
+      }
+    }]
+  }]
+}

--- a/spec/fixtures/github/runs.json
+++ b/spec/fixtures/github/runs.json
@@ -3,7 +3,7 @@
   "workflow_runs": [
     {
       "id": 1505649623,
-      "name": "Plugin Tests",
+      "name": "Discourse Plugin",
       "node_id": "WFR_kwLOBjsWBc5ZvmPX",
       "head_branch": "main",
       "head_sha": "ce0335b6799f19d933026a212b367258cffb2eae",

--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -63,6 +63,14 @@ def third_party_plugin
   "third_party_plugin"
 end
 
+def check_suite_id
+  "4469658997"
+end
+
+def check_run_id
+  "12020026492"
+end
+
 def git
   {
     branch: plugin_branch,
@@ -135,7 +143,23 @@ end
 
 def stub_github_test_request(response_body)
   plugin_path = "discourse-compatible-plugin"
-  stub_request(:get, "https://api.github.com/repos/paviliondev/#{plugin_path}/actions/runs?branch=#{plugin_branch}&status=completed&per_page=1&page=1").to_return(
+  stub_request(:get, "https://api.github.com/repos/paviliondev/#{plugin_path}/actions/runs?branch=#{plugin_branch}&status=completed&per_page=5&page=1").to_return(
+    status: 200,
+    body: response_body
+  )
+end
+
+def stub_github_test_check_request(response_body)
+  plugin_path = "discourse-compatible-plugin"
+  stub_request(:get, "https://api.github.com/repos/paviliondev/#{plugin_path}/check-suites/#{check_suite_id}/check-runs?status=completed").to_return(
+    status: 200,
+    body: response_body
+  )
+end
+
+def stub_github_annotations_request(response_body)
+  plugin_path = "discourse-compatible-plugin"
+  stub_request(:get, "https://api.github.com/repos/paviliondev/#{plugin_path}/check-runs/#{check_run_id}/annotations").to_return(
     status: 200,
     body: response_body
   )


### PR DESCRIPTION
- Restrict support to Discourse Plugin workflow
- Don't change status when only linting is failing
- Return a descriptive message when tests are failing